### PR TITLE
bump illuminate/http version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.1",
         "ext-mbstring": "*",
-        "illuminate/http": "^10.0"
+        "illuminate/http": "^10.0|^11.0|^12.0"
     },
     "minimum-stability": "dev"
 }

--- a/test/composer.json
+++ b/test/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=8.1",
         "notihnio/php-request-parser": "master",
-        "illuminate/http": "^10.0",
+        "illuminate/http": "^10.0|^11.0|^12.0",
         "phpunit/phpunit": "^9.0",
         "guzzlehttp/guzzle": "^7.0"
     },

--- a/test/tests/LaravelRequestsTest.php
+++ b/test/tests/LaravelRequestsTest.php
@@ -71,7 +71,6 @@ class LaravelRequestsTest extends TestCase
         $responseData = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertCount(4, $responseData);
-        $this->assertCount(5, $responseData["files"]["iconFile"]);
         $this->assertEquals("icon.png", $responseData["files"]["iconFile"]["name"]);
         $this->assertEquals("image/png", $responseData["files"]["iconFile"]["type"]);
         $this->assertNotNull($responseData["files"]["iconFile"]["tmp_name"]);

--- a/test/tests/SymfonyRequestsTest.php
+++ b/test/tests/SymfonyRequestsTest.php
@@ -71,7 +71,6 @@ class SymfonyRequestsTest extends TestCase
         $responseData = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertCount(4, $responseData);
-        $this->assertCount(5, $responseData["files"]["iconFile"]);
         $this->assertEquals("icon.png", $responseData["files"]["iconFile"]["name"]);
         $this->assertEquals("image/png", $responseData["files"]["iconFile"]["type"]);
         $this->assertNotNull($responseData["files"]["iconFile"]["tmp_name"]);


### PR DESCRIPTION
Required for symfony 7.x migrations . Tests all green for all combinations, removed redundant assertions that fails because of full_path extra file property presents in higher versions.